### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/src/app/auth/_components/session-tracker.tsx
+++ b/src/app/auth/_components/session-tracker.tsx
@@ -29,10 +29,15 @@ const SessionTracker = () => {
 
           // Intentar determinar el provider basado en el avatar URL
           if (user.image) {
-            if (user.image.includes("googleusercontent.com")) {
-              provider = "google";
-            } else if (user.image.includes("cdn.discordapp.com")) {
-              provider = "discord";
+            try {
+              const imageUrl = new URL(user.image);
+              if (imageUrl.hostname === "googleusercontent.com") {
+                provider = "google";
+              } else if (imageUrl.hostname === "cdn.discordapp.com") {
+                provider = "discord";
+              }
+            } catch (e) {
+              // If URL parsing fails, leave provider as "credentials"
             }
           }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ktumsh/hudlab/security/code-scanning/2](https://github.com/Ktumsh/hudlab/security/code-scanning/2)

The best way to fix this problem is to parse `user.image` as a URL, extract the hostname, and then match against a whitelist of valid Discord hosts (specifically, `cdn.discordapp.com`). This avoids the error-prone substring check and ensures the domain check is robust. The change is localized to the provider-detection logic (lines 31-37). You will need to use the `URL` constructor to parse the string as a URL and access the `.hostname` property. This only requires a standard library import, which is available natively in modern environments, so no new dependencies are required. If the URL parsing fails (malformed URL), you should safely ignore or default to "credentials".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
